### PR TITLE
Alias and affiliation updates redirect to project page... second try

### DIFF
--- a/web/includes/display.php
+++ b/web/includes/display.php
@@ -327,6 +327,7 @@ function unknown_results_as_table ($db,$project_id = NULL) {
 
 				echo '<span class="button"><form action="manage" method="post" class="short">
 					<input type=hidden name="domain" value="' . $row["domain"] . '">
+					<input type=hidden name="project_id" value="' . $project_id . '">
 					<input type=submit value="add an affiliation" name="confirmnew_affiliation">
 					</form></span>';
 			}
@@ -363,6 +364,7 @@ function unknown_results_as_table ($db,$project_id = NULL) {
 			if ($_SESSION['access_granted']) {
 				echo '<span class="button"><form action="manage" method="post" class="short">
 					<input type=hidden name="domain" value="' . $row["email"] . '">
+					<input type=hidden name="project_id" value="' . $project_id . '">
 					<input type=submit value="add as an alias" name="confirmnew_alias">
 					<input type=submit value="add an affiliation" name="confirmnew_affiliation">
 					</form></span>';

--- a/web/manage.php
+++ b/web/manage.php
@@ -595,6 +595,7 @@ if (ISSET($_POST["confirmnew_repo"])) {
 		</div> <!-- .sub-block -->
 		<div class="sub-block">
 		<form action="manage" id="newalias" method="post">
+		<input type="hidden" name="project_id" value="' . $project_id . '" />
 		<table>
 		<tr>
 		<td class="quarter"><label for="alias">This email: </label></td>
@@ -618,6 +619,7 @@ if (ISSET($_POST["confirmnew_repo"])) {
 
 	$alias = sanitize_input($db,$_POST['alias'],64);
 	$canonical = sanitize_input($db,$_POST['canonical'],64);
+	$project_id = sanitize_input($db,$_POST["project_id"],11);
 
 	if ($alias && $canonical) {
 
@@ -631,7 +633,15 @@ if (ISSET($_POST["confirmnew_repo"])) {
 
 	}
 
-	header("Location: people");
+	if ($project_id) {
+
+		header('Location: projects?id=' . $project_id);
+
+	} else {
+
+	header('Location: people');
+
+	}
 
 } elseif (ISSET($_POST["delete_alias"])) {
 
@@ -669,6 +679,7 @@ if (ISSET($_POST["confirmnew_repo"])) {
 		</div> <!-- .sub-block -->
 		<div class="sub-block">
 		<form action="manage" id="newaffiliation" method="post">
+		<input type="hidden" value="' . $project_id . '" name="project_id" />
 		<table>
 		<tr>
 		<td class="quarter"><label for="domain">This email or domain: </label></td>
@@ -703,6 +714,7 @@ if (ISSET($_POST["confirmnew_repo"])) {
 	$domain = sanitize_input($db,$_POST['domain'],64);
 	$affiliation = sanitize_input($db,$_POST['affiliation'],64);
 	$start_date = sanitize_input($db,$_POST['start_date'],10);
+	$project_id = sanitize_input($db,$_POST['project_id'],11);
 
 	if ($domain && $affiliation) {
 
@@ -725,7 +737,16 @@ if (ISSET($_POST["confirmnew_repo"])) {
 
 	}
 
-	header("Location: people");
+	if ($project_id) {
+
+		header("Location: projects?id=" . $project_id);
+
+	} else {
+
+		header("Location: people");
+
+	}
+
 
 } elseif (ISSET($_POST["delete_affiliation"])) {
 


### PR DESCRIPTION
Redirects updates to affiliations or aliases that originated on a project page, back to the project page. If originating from somewhere else, e.g. the people page, the header redirect still goes back to people. 